### PR TITLE
feat: add support for fetching subset of dataset by type

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,4 @@
 {
   "extends": "@sanity/semantic-release-preset",
-  "branches": ["main"]
+  "branches": ["main", {"name": "add-type-allowlist", "prerelease": true}]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.0-add-type-allowlist.1](https://github.com/sanity-io/groq-store/compare/v1.0.4...v1.1.0-add-type-allowlist.1) (2022-11-14)
+
+### Features
+
+- add support for fetching subset of dataset by type ([0e06463](https://github.com/sanity-io/groq-store/commit/0e06463cb9b79669c541186f379ab2d7beccbcad))
+
 ## [1.0.4](https://github.com/sanity-io/groq-store/compare/v1.0.3...v1.0.4) (2022-11-10)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ const store = groqStore({
   // Optional EventSource. Necessary to authorize using token in the browser, since
   // the native window.EventSource does not accept headers.
   // EventSource: SanityEventSource,
+
+  // Optional allow list filter for document types. You can use this to limit the amount of documents by declaring the types you want to sync. Note that since you're fetching a subset of your dataset, queries that works against your Content Lake might not work against the local groq-store.
+  allowTypes: ['post', 'page', 'product', 'sanity.imageAsset'],
 })
 
 store.query(groq`*[_type == "author"]`).then((docs) => {

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const store = groqStore({
   // EventSource: SanityEventSource,
 
   // Optional allow list filter for document types. You can use this to limit the amount of documents by declaring the types you want to sync. Note that since you're fetching a subset of your dataset, queries that works against your Content Lake might not work against the local groq-store.
-  allowTypes: ['post', 'page', 'product', 'sanity.imageAsset'],
+  includeTypes: ['post', 'page', 'product', 'sanity.imageAsset'],
 })
 
 store.query(groq`*[_type == "author"]`).then((docs) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/groq-store",
-  "version": "1.0.4",
+  "version": "1.1.0-add-type-allowlist.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/groq-store",
-      "version": "1.0.4",
+      "version": "1.1.0-add-type-allowlist.1",
       "license": "MIT",
       "dependencies": {
         "@sanity/types": "^2.35.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/groq-store",
-  "version": "1.0.4",
+  "version": "1.1.0-add-type-allowlist.1",
   "description": "Stream dataset to memory for in-memory querying",
   "keywords": [
     "sanity",

--- a/src/browser/getDocuments.ts
+++ b/src/browser/getDocuments.ts
@@ -10,13 +10,17 @@ export const getDocuments: EnvImplementations['getDocuments'] = async function g
   dataset,
   token,
   documentLimit,
+  allowTypes = [],
 }: {
   projectId: string
   dataset: string
   token?: string
   documentLimit?: number
+  allowTypes?: string[]
 }): Promise<SanityDocument[]> {
-  const url = `https://${projectId}.api.sanity.io/v1/data/export/${dataset}`
+  const baseUrl = `https://${projectId}.api.sanity.io/v1/data/export/${dataset}`
+  const params = allowTypes.length > 0 ? new URLSearchParams({types: allowTypes?.join(',')}) : ''
+  const url = `${baseUrl}?${params}`
   const headers = token ? {Authorization: `Bearer ${token}`} : undefined
   const response = await fetch(url, {credentials: 'include', headers})
 

--- a/src/browser/getDocuments.ts
+++ b/src/browser/getDocuments.ts
@@ -10,16 +10,17 @@ export const getDocuments: EnvImplementations['getDocuments'] = async function g
   dataset,
   token,
   documentLimit,
-  allowTypes = [],
+  includeTypes = [],
 }: {
   projectId: string
   dataset: string
   token?: string
   documentLimit?: number
-  allowTypes?: string[]
+  includeTypes?: string[]
 }): Promise<SanityDocument[]> {
   const baseUrl = `https://${projectId}.api.sanity.io/v1/data/export/${dataset}`
-  const params = allowTypes.length > 0 ? new URLSearchParams({types: allowTypes?.join(',')}) : ''
+  const params =
+    includeTypes.length > 0 ? new URLSearchParams({types: includeTypes?.join(',')}) : ''
   const url = `${baseUrl}?${params}`
   const headers = token ? {Authorization: `Bearer ${token}`} : undefined
   const response = await fetch(url, {credentials: 'include', headers})
@@ -46,7 +47,9 @@ export const getDocuments: EnvImplementations['getDocuments'] = async function g
 
     if (documentLimit && documents.length > documentLimit) {
       reader.cancel('Reached document limit')
-      throw new Error(`Error streaming dataset: Reached limit of ${documentLimit} documents`)
+      throw new Error(
+        `Error streaming dataset: Reached limit of ${documentLimit} documents. Try using the includeTypes option to reduce the amount of documents, or increase the limit.`
+      )
     }
   } while (!result.done)
 

--- a/src/node/getDocuments.ts
+++ b/src/node/getDocuments.ts
@@ -9,16 +9,17 @@ export const getDocuments: EnvImplementations['getDocuments'] = function getDocu
   dataset,
   token,
   documentLimit,
-  allowTypes = [],
+  includeTypes = [],
 }: {
   projectId: string
   dataset: string
   token?: string
   documentLimit?: number
-  allowTypes?: string[]
+  includeTypes?: string[]
 }): Promise<SanityDocument[]> {
   const baseUrl = `https://${projectId}.api.sanity.io/v1/data/export/${dataset}`
-  const params = allowTypes.length > 0 ? new URLSearchParams({types: allowTypes?.join(',')}) : ''
+  const params =
+    includeTypes.length > 0 ? new URLSearchParams({types: includeTypes?.join(',')}) : ''
   const url = `${baseUrl}?${params}`
   const headers = token ? {Authorization: `Bearer ${token}`} : undefined
 

--- a/src/node/getDocuments.ts
+++ b/src/node/getDocuments.ts
@@ -9,58 +9,60 @@ export const getDocuments: EnvImplementations['getDocuments'] = function getDocu
   dataset,
   token,
   documentLimit,
+  allowTypes = [],
 }: {
   projectId: string
   dataset: string
   token?: string
   documentLimit?: number
+  allowTypes?: string[]
 }): Promise<SanityDocument[]> {
+  const baseUrl = `https://${projectId}.api.sanity.io/v1/data/export/${dataset}`
+  const params = allowTypes.length > 0 ? new URLSearchParams({types: allowTypes?.join(',')}) : ''
+  const url = `${baseUrl}?${params}`
   const headers = token ? {Authorization: `Bearer ${token}`} : undefined
 
   return new Promise((resolve, reject) => {
-    get(
-      {url: `https://${projectId}.api.sanity.io/v1/data/export/${dataset}`, headers},
-      (err, response) => {
-        if (err) {
-          reject(err)
-          return
-        }
-
-        response.setEncoding('utf8')
-
-        const chunks: Buffer[] = []
-        if (response.statusCode !== 200) {
-          response
-            .on('data', (chunk: Buffer) => chunks.push(chunk))
-            .on('end', () => {
-              const body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
-              reject(new Error(`Error streaming dataset: ${getError(body)}`))
-            })
-          return
-        }
-
-        const documents: SanityDocument[] = []
-        response
-          .pipe(split(JSON.parse))
-          .on('data', (doc: StreamResult) => {
-            if (isStreamError(doc)) {
-              reject(new Error(`Error streaming dataset: ${doc.error}`))
-              return
-            }
-
-            if (doc && isRelevantDocument(doc)) {
-              documents.push(doc)
-            }
-
-            if (documentLimit && documents.length > documentLimit) {
-              reject(
-                new Error(`Error streaming dataset: Reached limit of ${documentLimit} documents`)
-              )
-              response.destroy()
-            }
-          })
-          .on('end', () => resolve(documents))
+    get({url, headers}, (err, response) => {
+      if (err) {
+        reject(err)
+        return
       }
-    )
+
+      response.setEncoding('utf8')
+
+      const chunks: Buffer[] = []
+      if (response.statusCode !== 200) {
+        response
+          .on('data', (chunk: Buffer) => chunks.push(chunk))
+          .on('end', () => {
+            const body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+            reject(new Error(`Error streaming dataset: ${getError(body)}`))
+          })
+        return
+      }
+
+      const documents: SanityDocument[] = []
+      response
+        .pipe(split(JSON.parse))
+        .on('data', (doc: StreamResult) => {
+          if (isStreamError(doc)) {
+            reject(new Error(`Error streaming dataset: ${doc.error}`))
+            return
+          }
+
+          if (doc && isRelevantDocument(doc)) {
+            documents.push(doc)
+          }
+
+          if (documentLimit && documents.length > documentLimit) {
+            reject(
+              new Error(`Error streaming dataset: Reached limit of ${documentLimit} documents`)
+            )
+            response.destroy()
+          }
+        })
+        .on('end', () => resolve(documents))
+    })
   })
 }

--- a/src/syncingDataset.ts
+++ b/src/syncingDataset.ts
@@ -22,11 +22,11 @@ export function getSyncingDataset(
     overlayDrafts,
     documentLimit,
     token,
-    allowTypes,
+    includeTypes,
   } = config
 
   if (!useListener) {
-    const loaded = getDocuments({projectId, dataset, documentLimit, token, allowTypes})
+    const loaded = getDocuments({projectId, dataset, documentLimit, token, includeTypes})
       .then(onUpdate)
       .then(noop)
     return {unsubscribe: noop, loaded}
@@ -65,7 +65,7 @@ export function getSyncingDataset(
   return {unsubscribe: listener.unsubscribe, loaded}
 
   async function onOpen() {
-    const initial = await getDocuments({projectId, dataset, documentLimit, token, allowTypes})
+    const initial = await getDocuments({projectId, dataset, documentLimit, token, includeTypes})
     documents = applyBufferedMutations(initial, buffer)
     documents.forEach((doc) => indexedDocuments.set(doc._id, doc))
     onUpdate(documents)

--- a/src/syncingDataset.ts
+++ b/src/syncingDataset.ts
@@ -15,10 +15,18 @@ export function getSyncingDataset(
   onNotifyUpdate: (docs: SanityDocument[]) => void,
   {getDocuments, EventSource}: EnvImplementations
 ): Subscription & {loaded: Promise<void>} {
-  const {projectId, dataset, listen: useListener, overlayDrafts, documentLimit, token} = config
+  const {
+    projectId,
+    dataset,
+    listen: useListener,
+    overlayDrafts,
+    documentLimit,
+    token,
+    allowTypes,
+  } = config
 
   if (!useListener) {
-    const loaded = getDocuments({projectId, dataset, documentLimit, token})
+    const loaded = getDocuments({projectId, dataset, documentLimit, token, allowTypes})
       .then(onUpdate)
       .then(noop)
     return {unsubscribe: noop, loaded}
@@ -57,7 +65,7 @@ export function getSyncingDataset(
   return {unsubscribe: listener.unsubscribe, loaded}
 
   async function onOpen() {
-    const initial = await getDocuments({projectId, dataset, documentLimit, token})
+    const initial = await getDocuments({projectId, dataset, documentLimit, token, allowTypes})
     documents = applyBufferedMutations(initial, buffer)
     documents.forEach((doc) => indexedDocuments.set(doc._id, doc))
     onUpdate(documents)

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,25 +30,49 @@ export interface GroqSubscription {
 
 export interface EnvImplementations {
   EventSource: typeof EventSource | typeof EventSourcePolyfill
-  getDocuments: (options: {
-    projectId: string
-    dataset: string
-    token?: string
-    documentLimit?: number
-    allowTypes?: string[]
-  }) => Promise<SanityDocument[]>
+  getDocuments: (
+    options: Pick<Config, 'projectId' | 'dataset' | 'token' | 'documentLimit' | 'includeTypes'>
+  ) => Promise<SanityDocument[]>
 }
 
 export interface Config {
   projectId: string
   dataset: string
+  /**
+   * Keep dataset up to date with remote changes.
+   * @default true
+   */
   listen?: boolean
+  /**
+   * Optional token, if you want to receive drafts, or read data from private datasets
+   * NOTE: Needs custom EventSource to work in browsers
+   */
   token?: string
+  /**
+   * Optional limit on number of documents, to prevent using too much memory unexpectedly
+   * Throws on the first operation (query, retrieval, subscription) if reaching this limit.
+   */
   documentLimit?: number
+  /**
+   * "Replaces" published documents with drafts, if available.
+   * Note that document IDs will not reflect draft status, currently
+   */
   overlayDrafts?: boolean
+  /**
+   * Throttle the event emits to batch updates.
+   * @default 50
+   */
   subscriptionThrottleMs?: number
+  /**
+   * Optional EventSource. Necessary to authorize using token in the browser, since
+   * the native window.EventSource does not accept headers.
+   */
   EventSource?: EnvImplementations['EventSource']
-  allowTypes?: string[]
+  /**
+   * Optional allow list filter for document types. You can use this to limit the amount of documents by declaring the types you want to sync. Note that since you're fetching a subset of your dataset, queries that works against your Content Lake might not work against the local groq-store.
+   * @example ['page', 'product', 'sanity.imageAsset']
+   */
+  includeTypes?: string[]
 }
 export interface GroqStore {
   query: <R = any>(groqQuery: string, params?: Record<string, unknown> | undefined) => Promise<R>

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface EnvImplementations {
     dataset: string
     token?: string
     documentLimit?: number
+    allowTypes?: string[]
   }) => Promise<SanityDocument[]>
 }
 
@@ -47,6 +48,7 @@ export interface Config {
   overlayDrafts?: boolean
   subscriptionThrottleMs?: number
   EventSource?: EnvImplementations['EventSource']
+  allowTypes?: string[]
 }
 export interface GroqStore {
   query: <R = any>(groqQuery: string, params?: Record<string, unknown> | undefined) => Promise<R>

--- a/test/allowList.test.ts
+++ b/test/allowList.test.ts
@@ -1,0 +1,22 @@
+import * as config from './config'
+import {groqStore, groq} from '../src'
+import {GroqStore} from '../src/types'
+
+describe('allowList', () => {
+  jest.setTimeout(30000)
+
+  let store: GroqStore
+
+  beforeAll(() => {
+    store = groqStore({...config, listen: false, overlayDrafts: true, allowTypes: ['product']})
+  })
+
+  afterAll(async () => {
+    await store.close()
+  })
+
+  test('only allow product documents in store', async () => {
+    expect(await store.query(groq`count(*[_type == "vendor"])`)).toEqual(0)
+    expect(await store.query(groq`count(*[_type == "product"])`)).toEqual(11)
+  })
+})

--- a/test/allowList.test.ts
+++ b/test/allowList.test.ts
@@ -8,7 +8,7 @@ describe('allowList', () => {
   let store: GroqStore
 
   beforeAll(() => {
-    store = groqStore({...config, listen: false, overlayDrafts: true, allowTypes: ['product']})
+    store = groqStore({...config, listen: false, overlayDrafts: true, includeTypes: ['product']})
   })
 
   afterAll(async () => {


### PR DESCRIPTION
Get the prerelease using: `npm i --save-exact @sanity/groq-store@add-type-allowlist`

This PR adds support for `includeTypes: [// list of document types]` as one strategy to limit which documents to sync to the groq-store. Of course, this has some foot guns since it's easy enough to forget when you're joining references and so on. I didn't get the test to run properly because I wasn't sure how to configure the local dev environment. Hope it isn't too far off the mark! 