### PR TITLE
Pass params properly to groq-js

### DIFF
--- a/src/groqStore.ts
+++ b/src/groqStore.ts
@@ -30,7 +30,7 @@ export function groqStore(config: Config, envImplementations: EnvImplementations
 
   async function query<R = any>(groqQuery: string, params?: Record<string, unknown>): Promise<R> {
     await loadDataset()
-    const tree = parse(groqQuery)
+    const tree = parse(groqQuery, {params})
     const result = await evaluate(tree, {dataset: documents, params})
     return result.get()
   }


### PR DESCRIPTION
groq-js needs to know about parameters at parse-time in order to correctly distinguish that `title[$locale]` should be an attribute access and not an array filtering.