### PR TITLE
`sideEffects` should be a bool

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "dist/browser/groq-store.js",
   "module": "dist/browser/groq-store.modern.js",
   "typings": "dist/typings/index.d.ts",
-  "sideEffects": "false",
+  "sideEffects": false,
   "scripts": {
     "start": "cd example && npm start",
     "prebuild": "rimraf dist",


### PR DESCRIPTION
Per [webpack docs](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free), it seems this should be a bool rather than a string.  Some bundlers emit warnings on this otherwise:

```
8:59:48 AM:  > ../../node_modules/@sanity/groq-store/package.json:9:17: warning: The value for "sideEffects" must be a boolean or an array
8:59:48 AM:     9 │   "sideEffects": "false",
8:59:48 AM:       ╵                  ^

```