### PR TITLE
feat: bump to groq-js v0.4 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @sanity/groq-store
 
-[![npm version](https://img.shields.io/npm/v/@sanity/groq-store.svg?style=flat-square)](http://browsenpm.org/package/@sanity/groq-store)[![Build Status](https://img.shields.io/travis/sanity-io/groq-store/master.svg?style=flat-square)](https://travis-ci.org/sanity-io/groq-store)![npm bundle size](https://img.shields.io/bundlephobia/minzip/@sanity/groq-store?style=flat-square)
+[![npm version](https://img.shields.io/npm/v/@sanity/groq-store.svg?style=flat-square)](https://www.npmjs.com/package/@sanity/groq-store)[![Build Status](https://img.shields.io/travis/sanity-io/groq-store/master.svg?style=flat-square)](https://travis-ci.org/sanity-io/groq-store)![npm bundle size](https://img.shields.io/bundlephobia/minzip/@sanity/groq-store?style=flat-square)
 
 In-memory GROQ store. Streams all available documents from Sanity into an in-memory database and allows you to query them there.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eventsource": "^1.0.7",
         "fast-deep-equal": "^3.1.3",
         "groq": "^2.0.9",
-        "groq-js": "0.4.0-beta.0",
+        "groq-js": "^0.4.0-beta.1",
         "mendoza": "^2.1.1",
         "simple-get": "^4.0.0",
         "split2": "^3.2.2",
@@ -6262,9 +6262,9 @@
       }
     },
     "node_modules/groq-js": {
-      "version": "0.4.0-beta.0",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.0.tgz",
-      "integrity": "sha512-quBGIJRAxtUfKrK0+98UsxLuCLks7WyUXv6uNbW5UaoPZCQrgxDlSmVTJ0LcXeKH57KDHsI7JP2P9NhREoRuzg=="
+      "version": "0.4.0-beta.1",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.1.tgz",
+      "integrity": "sha512-jHXB2AVRHO5Zj/pDRcrCCi284uHnUxUhH62npVxL+o47dLqgOcOQeBXxSHz1Ve07EDkRHj/W/AG7TB23RWInFQ=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -20553,9 +20553,9 @@
       "integrity": "sha512-Ed9YFs4B7DMmVAzAwDMnC/6FjRnwrIbpNpBbAep2zWR5L+4hcXgRV5C/2L6DDaEqYfrJUdRKf6jRipVnDzIaQA=="
     },
     "groq-js": {
-      "version": "0.4.0-beta.0",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.0.tgz",
-      "integrity": "sha512-quBGIJRAxtUfKrK0+98UsxLuCLks7WyUXv6uNbW5UaoPZCQrgxDlSmVTJ0LcXeKH57KDHsI7JP2P9NhREoRuzg=="
+      "version": "0.4.0-beta.1",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.1.tgz",
+      "integrity": "sha512-jHXB2AVRHO5Zj/pDRcrCCi284uHnUxUhH62npVxL+o47dLqgOcOQeBXxSHz1Ve07EDkRHj/W/AG7TB23RWInFQ=="
     },
     "growly": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eventsource": "^1.0.7",
         "fast-deep-equal": "^3.1.3",
         "groq": "^2.0.9",
-        "groq-js": "^0.3.0",
+        "groq-js": "0.4.0-beta.0",
         "mendoza": "^2.1.1",
         "simple-get": "^4.0.0",
         "split2": "^3.2.2",
@@ -6262,9 +6262,9 @@
       }
     },
     "node_modules/groq-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.3.0.tgz",
-      "integrity": "sha512-aMV+X2rWmrp7Zb63OcXr6X0ItfpAg/fiZbTeQeVLAyPwoGVnvQKNEi32rhziuLHJLIJeWjtJm7IKjwDwhyLhFA=="
+      "version": "0.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.0.tgz",
+      "integrity": "sha512-quBGIJRAxtUfKrK0+98UsxLuCLks7WyUXv6uNbW5UaoPZCQrgxDlSmVTJ0LcXeKH57KDHsI7JP2P9NhREoRuzg=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -20553,9 +20553,9 @@
       "integrity": "sha512-Ed9YFs4B7DMmVAzAwDMnC/6FjRnwrIbpNpBbAep2zWR5L+4hcXgRV5C/2L6DDaEqYfrJUdRKf6jRipVnDzIaQA=="
     },
     "groq-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.3.0.tgz",
-      "integrity": "sha512-aMV+X2rWmrp7Zb63OcXr6X0ItfpAg/fiZbTeQeVLAyPwoGVnvQKNEi32rhziuLHJLIJeWjtJm7IKjwDwhyLhFA=="
+      "version": "0.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.0.tgz",
+      "integrity": "sha512-quBGIJRAxtUfKrK0+98UsxLuCLks7WyUXv6uNbW5UaoPZCQrgxDlSmVTJ0LcXeKH57KDHsI7JP2P9NhREoRuzg=="
     },
     "growly": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eventsource": "^1.0.7",
     "fast-deep-equal": "^3.1.3",
     "groq": "^2.0.9",
-    "groq-js": "^0.3.0",
+    "groq-js": "^0.4.0-beta.0",
     "mendoza": "^2.1.1",
     "simple-get": "^4.0.0",
     "split2": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eventsource": "^1.0.7",
     "fast-deep-equal": "^3.1.3",
     "groq": "^2.0.9",
-    "groq-js": "0.4.0-beta.0",
+    "groq-js": "^0.4.0-beta.1",
     "mendoza": "^2.1.1",
     "simple-get": "^4.0.0",
     "split2": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eventsource": "^1.0.7",
     "fast-deep-equal": "^3.1.3",
     "groq": "^2.0.9",
-    "groq-js": "^0.4.0-beta.0",
+    "groq-js": "0.4.0-beta.0",
     "mendoza": "^2.1.1",
     "simple-get": "^4.0.0",
     "split2": "^3.2.2",

--- a/src/groqStore.ts
+++ b/src/groqStore.ts
@@ -31,7 +31,7 @@ export function groqStore(config: Config, envImplementations: EnvImplementations
   async function query<R = any>(groqQuery: string, params?: Record<string, unknown>): Promise<R> {
     await loadDataset()
     const tree = parse(groqQuery, {params})
-    const result = await evaluate(tree, {dataset: documents, params})
+    const result = await evaluate(tree as any, {dataset: documents, params})
     return result.get()
   }
 


### PR DESCRIPTION
Why the beta? Typically we would err on the side of caution, but in this case the version of groq-js that is currently shipping with next-sanity is seeing a serious performance regression, it’s better for our users to go all in on the new beta esepcially as this is used to generate editor facing previews.

After merge the next publish to npm should be `v0.3.0` on `@latest`.