### PR TITLE
fix: exclude source and test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/browser/groq-store.modern.js",
   "typings": "dist/typings/index.d.ts",
   "sideEffects": false,
+  "files": ["dist"],
   "scripts": {
     "start": "cd example && npm start",
     "prebuild": "rimraf dist",


### PR DESCRIPTION
Only npm pack what's needed, we're currently including [most of what's on the repo](https://unpkg.com/browse/@sanity/groq-store@0.3.0/). Here's the diff when running `npm pack --dry`:

```diff
 npm notice === Tarball Contents === 
-npm notice 205B   .editorconfig                         
-npm notice 258B   .eslintrc                             
-npm notice 508B   .github/workflows/test.yml            
-npm notice 91B    .prettierrc                           
 npm notice 1.1kB  LICENSE                               
 npm notice 2.2kB  README.md                             
 npm notice 8.3kB  dist/browser/groq-store.js            
 npm notice 26.1kB dist/browser/groq-store.js.map        
 npm notice 6.0kB  dist/browser/groq-store.modern.js     
 npm notice 26.0kB dist/browser/groq-store.modern.js.map 
 npm notice 13.5kB dist/node/groq-store.js               
 npm notice 30.6kB dist/node/groq-store.js.map           
 npm notice 120B   dist/typings/browser/getDocuments.d.ts
 npm notice 204B   dist/typings/browser/index.d.ts       
 npm notice 51B    dist/typings/browser/support.d.ts     
 npm notice 188B   dist/typings/drafts.d.ts              
 npm notice 344B   dist/typings/exportUtils.d.ts         
 npm notice 169B   dist/typings/groqStore.d.ts           
 npm notice 202B   dist/typings/index.d.ts               
 npm notice 280B   dist/typings/listen.d.ts              
 npm notice 120B   dist/typings/node/getDocuments.d.ts   
 npm notice 51B    dist/typings/node/support.d.ts        
 npm notice 165B   dist/typings/patch.d.ts               
 npm notice 328B   dist/typings/syncingDataset.d.ts      
 npm notice 2.0kB  dist/typings/types.d.ts               
-npm notice 685B   example/example.css                   
-npm notice 2.1kB  example/example.ts                    
-npm notice 771B   example/index.html                    
-npm notice 257B   example/package.json                  
 npm notice 2.0kB  package.json                          
-npm notice 3.9kB  src/browser/getDocuments.ts           
-npm notice 544B   src/browser/index.ts                  
-npm notice 303B   src/browser/support.ts                
-npm notice 279B   src/drafts.ts                         
-npm notice 796B   src/exportUtils.ts                    
-npm notice 3.2kB  src/groqStore.ts                      
-npm notice 620B   src/index.ts                          
-npm notice 2.1kB  src/listen.ts                         
-npm notice 2.0kB  src/node/getDocuments.ts              
-npm notice 208B   src/node/support.ts                   
-npm notice 317B   src/patch.ts                          
-npm notice 6.3kB  src/syncingDataset.ts                 
-npm notice 1.8kB  src/types.ts                          
-npm notice 24B    test/.eslintrc                        
-npm notice 161B   test/config.ts                        
-npm notice 708B   test/limits.test.ts                   
-npm notice 758B   test/query.test.ts                    
-npm notice 5.9kB  test/subscribe.test.ts                
-npm notice 1.4kB  tsconfig.json                         
-npm notice 374B   types/simple-get.d.ts                 
 npm notice === Tarball Details === 
 npm notice name:          @sanity/groq-store                      
 npm notice version:       0.3.0                                   
 npm notice filename:      @sanity/groq-store-0.3.0.tgz            
-npm notice package size:  40.0 kB                                 
+npm notice package size:  29.7 kB  
-npm notice unpacked size: 156.6 kB                                
+npm notice unpacked size: 120.0 kB
-npm notice total files:   50                                      
+npm notice total files:   22 
```