### PR TITLE
Allow authentication with token in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In-memory GROQ store. Streams all available documents from Sanity into an in-mem
 ## Caveats
 
 - Streams _entire_ dataset to memory, so generally not recommended for large datasets
-- Does not work with tokens in browser (currently)
+- Needs custom event source to work with tokens in browser
 
 ## Installation
 
@@ -24,6 +24,7 @@ npm install --save @sanity/groq-store
 
 ```js
 import {groqStore, groq} from '@sanity/groq-store'
+// import SanityEventSource from '@sanity/eventsource'
 
 const store = groqStore({
   projectId: 'abc123',
@@ -37,12 +38,16 @@ const store = groqStore({
   overlayDrafts: true,
 
   // Optional token, if you want to receive drafts, or read data from private datasets
-  // NOTE: Does _not_ work in browsers (yet)
+  // NOTE: Needs custom EventSource to work in browsers
   token: 'someAuthToken',
 
   // Optional limit on number of documents, to prevent using too much memory unexpectedly
   // Throws on the first operation (query, retrieval, subscription) if reaching this limit.
   documentLimit: 10000,
+
+  // Optional EventSource. Necessary to authorize using token in the browser, since
+  // the native window.EventSource does not accept headers.
+  // EventSource: SanityEventSource,
 })
 
 store.query(groq`*[_type == "author"]`).then((docs) => {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,16 +1,19 @@
-import EventSource from 'eventsource'
 import {groqStore as groqStoreApi} from '../groqStore'
-import {Config, EnvImplementations, GroqStore} from '../types'
+import {Config, GroqStore} from '../types'
 import {getDocuments} from './getDocuments'
 import {assertEnvSupport} from './support'
 
 export function groqStore(config: Config): GroqStore {
   assertEnvSupport()
 
+  const EventSource = config.EventSource ?? window.EventSource
+
+  if (config.token && EventSource === window.EventSource) {
+    throw new Error('`token` option not currently supported in browser')
+  }
+
   return groqStoreApi(config, {
-    // Need to use eventsource library to enable authentication with token (e.g. Firefox and Safari)
-    // Native EventSource implementation does not accept headers
-    EventSource: (EventSource as any) as EnvImplementations['EventSource'],
+    EventSource,
     getDocuments,
   })
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -9,7 +9,7 @@ export function groqStore(config: Config): GroqStore {
   const EventSource = config.EventSource ?? window.EventSource
 
   if (config.token && EventSource === window.EventSource) {
-    throw new Error('`token` option not currently supported in browser')
+    throw new Error('When`token` option is used, `EventSource` option must also be provided. EventSource cannot be `window.EventSource`, as it does not support passing a token.')
   }
 
   return groqStoreApi(config, {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,17 +1,16 @@
+import EventSource from 'eventsource'
 import {groqStore as groqStoreApi} from '../groqStore'
-import {Config, GroqStore} from '../types'
+import {Config, EnvImplementations, GroqStore} from '../types'
 import {getDocuments} from './getDocuments'
 import {assertEnvSupport} from './support'
 
 export function groqStore(config: Config): GroqStore {
   assertEnvSupport()
 
-  if (config.token) {
-    throw new Error('`token` option not currently supported in browser')
-  }
-
   return groqStoreApi(config, {
-    EventSource: window.EventSource,
+    // Need to use eventsource library to enable authentication with token (e.g. Firefox and Safari)
+    // Native EventSource implementation does not accept headers
+    EventSource: (EventSource as any) as EnvImplementations['EventSource'],
     getDocuments,
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 /**
  * Note: Entry point for _browser_ build is in browser/index.ts
  */
-import EventSource from 'eventsource'
+import EventSourcePolyfill from 'eventsource'
 import {groqStore as groqStoreApi} from './groqStore'
-import {Config, EnvImplementations, GroqStore} from './types'
+import {Config, GroqStore} from './types'
 import {getDocuments} from './node/getDocuments'
 import {assertEnvSupport} from './node/support'
 
@@ -11,7 +11,7 @@ export function groqStore(config: Config): GroqStore {
   assertEnvSupport()
 
   return groqStoreApi(config, {
-    EventSource: (EventSource as any) as EnvImplementations['EventSource'],
+    EventSource: config.EventSource ?? EventSourcePolyfill,
     getDocuments,
   })
 }

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -14,8 +14,6 @@ const addEventSourceListener = (
   listener: EventListener
 ): void => {
   if (isNativeBrowserEventSource(eventSource)) {
-    // eslint-disable-next-line
-    console.log('😱😱😱 isNativeBrowserEventSource 😱😱😱')
     eventSource.addEventListener(type, listener, false)
   }
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -1,7 +1,30 @@
-import {Subscription, MutationEvent, Config, ApiError} from './types'
+import {Subscription, MutationEvent, Config, ApiError, EnvImplementations} from './types'
+
+type EventSourceInstance = InstanceType<EnvImplementations['EventSource']>
+
+const isNativeBrowserEventSource = (
+  eventSource: EventSourceInstance
+): eventSource is InstanceType<typeof globalThis.EventSource> =>
+  typeof window !== 'undefined' &&
+  eventSource.addEventListener === window.EventSource.prototype.addEventListener
+
+const addEventSourceListener = (
+  eventSource: EventSourceInstance,
+  type: string,
+  listener: EventListener
+): void => {
+  if (isNativeBrowserEventSource(eventSource)) {
+    // eslint-disable-next-line
+    console.log('😱😱😱 isNativeBrowserEventSource 😱😱😱')
+    eventSource.addEventListener(type, listener, false)
+  }
+
+  // Polyfilled event source does not accept option parameter
+  eventSource.addEventListener(type, listener)
+}
 
 export function listen(
-  EventSourceImpl: typeof EventSource,
+  EventSourceImpl: EnvImplementations['EventSource'],
   config: Config,
   handlers: {
     open: () => void
@@ -12,46 +35,38 @@ export function listen(
   const {projectId, dataset, token} = config
   const headers = token ? {Authorization: `Bearer ${token}`} : undefined
   const url = `https://${projectId}.api.sanity.io/v1/data/listen/${dataset}?query=*&effectFormat=mendoza`
-  const es = new EventSourceImpl(url, {withCredentials: true, headers} as any)
+  const es = new EventSourceImpl(url, {withCredentials: true, headers})
 
-  es.addEventListener('welcome', handlers.open, false)
+  addEventSourceListener(es, 'welcome', handlers.open)
 
-  es.addEventListener('mutation', getMutationParser(handlers.next), false)
+  addEventSourceListener(es, 'mutation', getMutationParser(handlers.next))
 
-  es.addEventListener(
-    'channelError',
-    (msg: any) => {
-      es.close()
+  addEventSourceListener(es, 'channelError', (msg: any) => {
+    es.close()
 
-      let data
-      try {
-        data = JSON.parse(msg.data) as ApiError
-      } catch (err) {
-        handlers.error(new Error('Unknown error parsing listener message'))
-        return
-      }
+    let data
+    try {
+      data = JSON.parse(msg.data) as ApiError
+    } catch (err) {
+      handlers.error(new Error('Unknown error parsing listener message'))
+      return
+    }
 
-      handlers.error(
-        new Error(data.message || data.error || `Listener returned HTTP ${data.statusCode}`)
+    handlers.error(
+      new Error(data.message || data.error || `Listener returned HTTP ${data.statusCode}`)
+    )
+  })
+
+  addEventSourceListener(es, 'error', (err: Event) => {
+    const origin = typeof window !== 'undefined' && window.location.origin
+    const hintSuffix = origin ? `, and that the CORS-origin (${origin}) is allowed` : ''
+    const errorMessage = isErrorLike(err) ? ` (${err.message})` : ''
+    handlers.error(
+      new Error(
+        `Error establishing listener - check that the project ID and dataset are correct${hintSuffix}${errorMessage}`
       )
-    },
-    false
-  )
-
-  es.addEventListener(
-    'error',
-    (err) => {
-      const origin = typeof window !== 'undefined' && window.location.origin
-      const hintSuffix = origin ? `, and that the CORS-origin (${origin}) is allowed` : ''
-      const errorMessage = isErrorLike(err) ? ` (${err.message})` : ''
-      handlers.error(
-        new Error(
-          `Error establishing listener - check that the project ID and dataset are correct${hintSuffix}${errorMessage}`
-        )
-      )
-    },
-    false
-  )
+    )
+  })
 
   return {
     unsubscribe: (): Promise<void> => Promise.resolve(es.close()),

--- a/src/syncingDataset.ts
+++ b/src/syncingDataset.ts
@@ -15,10 +15,12 @@ export function getSyncingDataset(
   onNotifyUpdate: (docs: SanityDocument[]) => void,
   {getDocuments, EventSource}: EnvImplementations
 ): Subscription & {loaded: Promise<void>} {
-  const {projectId, dataset, listen: useListener, overlayDrafts, documentLimit} = config
+  const {projectId, dataset, listen: useListener, overlayDrafts, documentLimit, token} = config
 
   if (!useListener) {
-    const loaded = getDocuments({projectId, dataset, documentLimit}).then(onUpdate).then(noop)
+    const loaded = getDocuments({projectId, dataset, documentLimit, token})
+      .then(onUpdate)
+      .then(noop)
     return {unsubscribe: noop, loaded}
   }
 
@@ -55,7 +57,7 @@ export function getSyncingDataset(
   return {unsubscribe: listener.unsubscribe, loaded}
 
   async function onOpen() {
-    const initial = await getDocuments({projectId, dataset, documentLimit})
+    const initial = await getDocuments({projectId, dataset, documentLimit, token})
     documents = applyBufferedMutations(initial, buffer)
     documents.forEach((doc) => indexedDocuments.set(doc._id, doc))
     onUpdate(documents)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,5 @@
 import {SanityDocument} from '@sanity/types'
-
-export interface Config {
-  projectId: string
-  dataset: string
-  listen?: boolean
-  token?: string
-  documentLimit?: number
-  overlayDrafts?: boolean
-  subscriptionThrottleMs?: number
-}
+import EventSourcePolyfill from 'eventsource'
 
 export interface Subscription {
   unsubscribe: () => Promise<void>
@@ -38,7 +29,7 @@ export interface GroqSubscription {
 }
 
 export interface EnvImplementations {
-  EventSource: typeof EventSource
+  EventSource: typeof EventSource | typeof EventSourcePolyfill
   getDocuments: (options: {
     projectId: string
     dataset: string
@@ -47,6 +38,16 @@ export interface EnvImplementations {
   }) => Promise<SanityDocument[]>
 }
 
+export interface Config {
+  projectId: string
+  dataset: string
+  listen?: boolean
+  token?: string
+  documentLimit?: number
+  overlayDrafts?: boolean
+  subscriptionThrottleMs?: number
+  EventSource?: EnvImplementations['EventSource']
+}
 export interface GroqStore {
   query: <R = any>(groqQuery: string, params?: Record<string, unknown> | undefined) => Promise<R>
   getDocument: (documentId: string) => Promise<SanityDocument | null>


### PR DESCRIPTION
Allows https://github.com/sanity-io/next-sanity/pull/51, which makes the preview subscription hook work in Firefox and Safari: https://github.com/sanity-io/next-sanity/issues/49

Not sure if the below is how you would solve it?