### PR TITLE
Upgrade to groq-js 1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     # We test on all of the maintained versions: https://nodejs.org/en/about/releases/
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eventsource": "^1.0.7",
         "fast-deep-equal": "^3.1.3",
         "groq": "^2.0.9",
-        "groq-js": "^0.4.0-beta.2",
+        "groq-js": "^1.0.0",
         "mendoza": "^2.1.1",
         "simple-get": "^4.0.1",
         "split2": "^4.1.0",
@@ -6950,9 +6950,9 @@
       }
     },
     "node_modules/groq-js": {
-      "version": "0.4.0-beta.2",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.2.tgz",
-      "integrity": "sha512-jb9Jy8MQc6JvSHJCdhp5zxjgg0aeYJLkfDU/IWwA9edeTBKRcYdVWf4MSgVyCL2ggxVEVTj9b4HJj76IKnYVMA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.0.0.tgz",
+      "integrity": "sha512-j0CeL3AFYTc6xc4QGm5JXUXfqPP5cmQ4lttGpuSnWVhYuoaXlOaQETFcxlpEWW+lt1lfBtQNJ8xCeIp7BF9rWg=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -20905,9 +20905,9 @@
       "integrity": "sha512-j3HFq8Qwg36rREp2Xl2vecUz47LX6cedD8cqq+JKX0iNj9yiwelOSKpRS5jxhkDZQv5xBAiqtpU2Ylv5DQ5g2A=="
     },
     "groq-js": {
-      "version": "0.4.0-beta.2",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-0.4.0-beta.2.tgz",
-      "integrity": "sha512-jb9Jy8MQc6JvSHJCdhp5zxjgg0aeYJLkfDU/IWwA9edeTBKRcYdVWf4MSgVyCL2ggxVEVTj9b4HJj76IKnYVMA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.0.0.tgz",
+      "integrity": "sha512-j0CeL3AFYTc6xc4QGm5JXUXfqPP5cmQ4lttGpuSnWVhYuoaXlOaQETFcxlpEWW+lt1lfBtQNJ8xCeIp7BF9rWg=="
     },
     "growly": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eventsource": "^1.0.7",
     "fast-deep-equal": "^3.1.3",
     "groq": "^2.0.9",
-    "groq-js": "^0.4.0-beta.2",
+    "groq-js": "^1.0.1",
     "mendoza": "^2.1.1",
     "simple-get": "^4.0.1",
     "split2": "^4.1.0",


### PR DESCRIPTION
There seems to be some problems which we might need to fix in groq-js 1.0.1. Leaving this PR here for now.