### PR TITLE
Adding support for events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 /coverage
 *.iml
 .idea/
+.history
+.parcel-cache

--- a/example/example.ts
+++ b/example/example.ts
@@ -13,11 +13,15 @@ import {groqStore, Subscription} from '../src/browser'
   populate()
 
   let subscription: Subscription | null | undefined
-  const dataset = groqStore({
+  const store = groqStore({
     projectId: 'groqstore',
     dataset: 'fixture',
     listen: true,
     overlayDrafts: true,
+  })
+
+  store.on('datasetLoaded', ({dataset, documents}) => {
+    console.info(`Dataset "${dataset}" loaded with ${documents.length} documents`)
   })
 
   function attach() {
@@ -39,7 +43,7 @@ import {groqStore, Subscription} from '../src/browser'
     resultEl.value = '… querying …'
     localStorage.setItem('groqStore', queryEl.value)
     try {
-      onResult(await dataset.query(queryEl.value))
+      onResult(await store.query(queryEl.value))
     } catch (err: any) {
       onError(err.message || 'Unknown error')
     }
@@ -56,7 +60,7 @@ import {groqStore, Subscription} from '../src/browser'
       resultEl.value = '… querying …'
       executeBtnEl.disabled = true
       subscribeBtnEl.textContent = 'Unsubscribe'
-      subscription = dataset.subscribe(queryEl.value, {}, onResult)
+      subscription = store.subscribe(queryEl.value, {}, onResult)
     }
   }
 

--- a/example/example.ts
+++ b/example/example.ts
@@ -21,6 +21,7 @@ import {groqStore, Subscription} from '../src/browser'
   })
 
   store.on('datasetLoaded', ({dataset, documents}) => {
+    // eslint-disable-next-line no-console
     console.info(`Dataset "${dataset}" loaded with ${documents.length} documents`)
   })
 

--- a/example/index.html
+++ b/example/index.html
@@ -25,6 +25,6 @@
       </section>
     </div>
 
-    <script src="example.ts"></script>
+    <script src="example.ts" type="module"></script>
   </body>
 </html>

--- a/example/package.json
+++ b/example/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "description": "",
   "license": "MIT",
-  "main": "src/example.ts",
   "scripts": {
     "start": "parcel index.html"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.5"
-  }
+  },
+  "default": "example.ts"
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
+    "prettify": "prettier --write .",
     "start": "cd example && npm start",
     "test": "tsdx test"
   },

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,7 +3,7 @@ import {SanityDocument} from '@sanity/types'
 
 type Events = {
   /**
-   * Emitted after the dataset was loaded
+   * Emitted after the dataset was loaded.
    */
   datasetLoaded: {
     dataset: string
@@ -11,8 +11,8 @@ type Events = {
   }
 
   /**
-   * Emitted each time when the dataset changes. This happens when the dataset
-   * is initialised, and after mutations were applied through listeners.
+   * Emitted each time the dataset changes. This happens when the dataset
+   * is initialised, and after mutations are applied through listeners.
    */
   datasetChanged: {
     dataset: string

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,26 @@
+import {EventEmitter} from 'events'
+import {SanityDocument} from '@sanity/types'
+
+type Events = {
+  /**
+   * Emitted after the dataset was loaded
+   */
+  datasetLoaded: {
+    dataset: string
+    documents: SanityDocument[]
+  }
+
+  /**
+   * Emitted each time when the dataset changes. This happens when the dataset
+   * is initialised, and after mutations were applied through listeners.
+   */
+  datasetChanged: {
+    dataset: string
+    documents: SanityDocument[]
+  }
+}
+
+export interface TypedEventEmitter extends EventEmitter {
+  on<K extends keyof Events>(s: K, listener: (v: Events[K]) => void): this
+  emit<K extends keyof Events>(eventName: K, params: Events[K]): boolean
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import {SanityDocument} from '@sanity/types'
 import EventSourcePolyfill from 'eventsource'
+import {TypedEventEmitter} from './events'
 
 /** @public */
 export interface Subscription {
@@ -89,6 +90,7 @@ export interface GroqStore {
     callback: (err: Error | undefined, result?: R) => void
   ) => Subscription
   close: () => Promise<void>
+  on: TypedEventEmitter['on']
 }
 
 export interface ApiError {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,79 @@
+import EventSource from 'eventsource'
+import {groqStore as groqStoreApi} from '../src/groqStore'
+import {EnvImplementations, Config} from '../src/types'
+import * as baseConfig from './config'
+import * as listener from '../src/listen'
+import {MutationEvent} from '@sanity/client'
+
+describe('events', () => {
+  it('datasetLoaded fires when dataset is loaded', async () => {
+    const config: Config = {
+      ...baseConfig,
+      token: 'my-token',
+    }
+
+    const getDocuments = jest.fn().mockResolvedValue([{_id: 'foo', value: 'bar'}])
+    const datasetLoadedCb = jest.fn()
+
+    const store = groqStoreApi(config, {
+      EventSource: EventSource as any as EnvImplementations['EventSource'],
+      getDocuments,
+    })
+
+    store.on('datasetLoaded', datasetLoadedCb)
+
+    await store.query('*')
+
+    expect(datasetLoadedCb).toBeCalledTimes(1)
+    expect(datasetLoadedCb).toBeCalledWith({
+      dataset: 'fixture',
+      documents: [{_id: 'foo', value: 'bar'}],
+    })
+  })
+
+  it('datasetChanged fires each time the dataset changes', async () => {
+    const config: Config = {
+      ...baseConfig,
+      listen: true,
+      token: 'my-token',
+    }
+
+    jest.useFakeTimers()
+    jest.spyOn(listener, 'listen').mockImplementation((_esImpl, _config, handlers) => {
+      handlers.open()
+
+      // Call `next()` a little bit later to imitate a mutation received event
+      // eslint-disable-next-line max-nested-callbacks
+      setTimeout(() => handlers.next({} as any as MutationEvent), 50)
+
+      return {
+        unsubscribe: () => Promise.resolve(),
+      }
+    })
+
+    const getDocuments = jest.fn().mockResolvedValue([
+      {_id: 'foo', value: 'bar'},
+      // {_id: 'bar', value: 'foo'},
+    ])
+    const datasetChangedCb = jest.fn()
+
+    const store = groqStoreApi(config, {
+      EventSource: EventSource as any as EnvImplementations['EventSource'],
+      getDocuments,
+    })
+
+    store.on('datasetChanged', datasetChangedCb)
+
+    await store.query('*')
+
+    expect(datasetChangedCb).toBeCalledTimes(1)
+    expect(datasetChangedCb).toBeCalledWith({
+      dataset: 'fixture',
+      documents: [{_id: 'foo', value: 'bar'}],
+    })
+
+    jest.advanceTimersByTime(100)
+
+    expect(datasetChangedCb).toBeCalledTimes(2)
+  })
+})

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -51,10 +51,7 @@ describe('events', () => {
       }
     })
 
-    const getDocuments = jest.fn().mockResolvedValue([
-      {_id: 'foo', value: 'bar'},
-      // {_id: 'bar', value: 'foo'},
-    ])
+    const getDocuments = jest.fn().mockResolvedValue([{_id: 'foo', value: 'bar'}])
     const datasetChangedCb = jest.fn()
 
     const store = groqStoreApi(config, {


### PR DESCRIPTION
I'm using groq-store in a Node server and I'm wondering whether I can get some additional useful information out of that.
What I'm thinking is really basic, like "dataset was loaded with X documents", and a similar update whenever changes are received through the listener API.

My first idea was to support some eventing, like `store.on('datasetChanged', () => {...})`, so I gave it a go and tried to implement it.

Let me know what you think :)
