### PR TITLE
test: delete any category draft fixture before test run

### DIFF
--- a/test/subscribe.test.ts
+++ b/test/subscribe.test.ts
@@ -11,17 +11,26 @@ describe.runIf(config.token)(
     let errStore: GroqStore
 
     function deleteFixtureDocs() {
-      return client
-        .transaction()
-        .delete('fox')
-        .delete('drafts.fox')
-        .delete('category-awesome')
-        .commit({visibility: 'async'})
+      return (
+        client
+          .transaction()
+          .delete('fox')
+          .delete('drafts.fox')
+          .delete('category-awesome')
+          // Not expecting to see this draft, but in case someone messes up the dataset
+          .delete('drafts.category-awesome')
+          .commit({visibility: 'async'})
+      )
     }
 
     beforeAll(async () => {
       // Make sure we don't have any old fixtures laying around
-      client = createClient({...config, useCdn: false, apiVersion: '2021-06-07'})
+      client = createClient({
+        ...config,
+        useCdn: false,
+        apiVersion: '2021-06-07',
+        requestTagPrefix: 'sanity.groq-store.integration-test',
+      })
       await deleteFixtureDocs()
 
       store = groqStore({...config, listen: true, overlayDrafts: true})


### PR DESCRIPTION
Somehow a draft version of the category fixture had snuck in, causing the tests to fail since the draft was overlayed and expectations were thus not met.

This PR ensures we also delete the draft before running the tests, even if we do not expect it to show up.
Also snuck in a request tag prefix since it can be nice for us to see where these requests are coming from.