### PR TITLE
feat: parity between overlayDrafts and perspectives=previewDrafts

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export function compareString(a: string, b: string): number {
+  if (a > b) return 1
+  if (a < b) return -1
+  return 0
+}

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -4,7 +4,7 @@ import {GroqStore} from '../src/types'
 import {describe, beforeAll, afterAll, test, expect} from 'vitest'
 
 describe(
-  'query',
+  'query with overlayDrafts',
   () => {
     let store: GroqStore
 
@@ -36,6 +36,53 @@ describe(
         new Set(['category', 'product', 'sanity.imageAsset', 'vendor'])
       )
     })
+
+    test('populates _originalId', async () => {
+      const id = await store.query(groq`*[_type == "vendor"][0]._originalId`)
+      expect(id).toBe('01ca40b6-e7fd-4676-af25-33f591de51c0')
+    })
+
+    test('sorts based on _id', async () => {
+      const titles = await store.query(groq`*[_type == "vendor"].title`)
+      expect(titles).toEqual([
+        'Kracie',
+        'Nestlè',
+        'Ferrero',
+        'Freia',
+        'Malaco',
+        'Chocolates Garoto',
+        'Katjes',
+        'Cadbury',
+        'Totte Gott',
+      ])
+    })
   },
   {timeout: 30000}
 )
+
+describe('query without overlayDrafts', () => {
+  let store: GroqStore
+
+  beforeAll(() => {
+    store = groqStore({...config, listen: false, overlayDrafts: false})
+  })
+
+  afterAll(async () => {
+    await store.close()
+  })
+
+  test('sorts based on _id', async () => {
+    const titles = await store.query(groq`*[_type == "vendor"].title`)
+    expect(titles).toEqual([
+      'Kracie',
+      'Nestlè',
+      'Ferrero',
+      'Freia',
+      'Malaco',
+      'Chocolates Garoto',
+      'Katjes',
+      'Cadbury',
+      'Totte Gott',
+    ])
+  })
+})

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -32,12 +32,9 @@ describe(
       expect(await store.query(groq`*[_type == "vendor"][].title | order(@ asc) [3]`)).toEqual(
         'Freia'
       )
-      expect(await store.query(groq`array::unique(*._type)`)).toEqual([
-        'category',
-        'product',
-        'sanity.imageAsset',
-        'vendor',
-      ])
+      expect(new Set(await store.query(groq`array::unique(*._type)`))).toEqual(
+        new Set(['category', 'product', 'sanity.imageAsset', 'vendor'])
+      )
     })
   },
   {timeout: 30000}


### PR DESCRIPTION
## New description (after feedback)

This fixes two things:

1. It adds the `_originalId` property whenever overlayDrafts:true
2. It ensures that we always sort the dataset by `_id`

The second one is actually bug which has been here for quite a while.

## Original description 

Documents should always be sorted by `_id`, even when overlaying. This attempts to fix that, but:

- I was a bit unsure of how to write a test for this. Maybe under `query.test.ts`? I don't fully know how this fixture dataset works.
- Do we consider this a breaking change? 🤔 